### PR TITLE
make package "pip install"-able

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,14 @@ Options:
   -n NUMDOTS, --numdots=NUMDOTS
                         Number of dots
 ```
+
+## Installation
+
+Use ``pip`` to install directly from GitHub:
+
+```console
+$ pip install git+https://github.com/drpeteb/spotty#egg=spotty
+```
+
+The ``spotty`` command should then be available in your ``PATH`` as per usual.
+

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup
+
+setup(
+    name='spotty',
+    version='0.0.1',
+    py_modules=['spotty'],
+    entry_points={
+        'console_scripts': [
+            'spotty = spotty:main',
+        ],
+    },
+    install_requires=[
+        'numpy',
+        'matplotlib',
+    ],
+)

--- a/spotty.py
+++ b/spotty.py
@@ -101,8 +101,13 @@ def spotty(message, fontSize=100, borderSize=0.5, dotRadius=3, numDots=10000):
     return dotImage
 
 
-def main(argv):
-    """Parse arguments and call spotty"""
+def main(argv=None):
+    """Parse arguments and call spotty. If argv is None, sys.argv[1:] is
+    used.
+    
+    """
+    if argv is None:
+        argv = sys.argv[1:]
     
     usage = "usage: %prog message [options]"
     parser = OptionParser(usage=usage)


### PR DESCRIPTION
It's relatively easy to make a package suitable for automatic installation via pip. This PR implements the required changes and creates a console script called `spotty` which automatically finds the correct version of Python to use. (This is provided "for free" by setuptools.)

During development, one can use the `-e` option to `pip` to install the package via symlinks allowing modifications to `spotty.py` to be reflected immediately:

``` console
$ cd $DIRECTORY_WITH_SPOTTY_PY
$ pip install -e .
```

I've used the `py_modules` argument to `setup()` since this is a single-module package. Moving forward, it's slightly more idiomatic to use packages. (I.e. a `spotty` directory with an `__init__.py` file.) In this case, one can use the `packages` argument and the `find_packages` helper function.

Listing the requirements in the `setup.py` file will allow `pip` to automatically download any dependencies.
