### PR TITLE
add gitignore file for some common Python detritus

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# bytecode caches from Python 2 and 3
+*.pyc
+__pycache__
+
+# detritus from setuptools
+build
+dist
+*.egg-info
+


### PR DESCRIPTION
Add a simple .gitignore file to guard against inadvertent commits of Python
bytecode files or the output from setuptools (should PR #1 be merged).
